### PR TITLE
Add scripts for easy local testing and add a sitemap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:vivid
+MAINTAINER Tully Foote<tfoote@osrfoundation.org>
+
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -q -y curl net-tools python python-yaml build-essential ruby-dev  nodejs
+
+RUN gem install bundler --no-rdoc --no-ri
+# needed for nokogiri to install successfully
+RUN apt-get update && apt-get install -q -y zlib1g-dev
+COPY Gemfile /tmp/Gemfile
+RUN bundle install --gemfile=/tmp/Gemfile
+
+EXPOSE 4000
+VOLUME /tmp/jekyll
+WORKDIR /tmp/jekyll
+
+CMD jekyll serve -w --baseurl='' -d /tmp/_site

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
 gem 'github-pages'
+gem 'jekyll-sitemap'

--- a/README.md
+++ b/README.md
@@ -1,11 +1,25 @@
-## A "Getting Started" Guide for Developers Interested in Robotics
+# A "Getting Started" Guide for Developers Interested in Robotics
 
-[Learn TurtleBot] (http://learn.turtlebot.com/) is an open source getting started guide for web, mobile and maker developers interested in robotics.
+[Learn TurtleBot](http://learn.turtlebot.com/) is an open source getting started guide for web, mobile and maker developers interested in robotics.
 
-[Go to the tutorials] (http://learn.turtlebot.com/)
+[Go to the tutorials](http://learn.turtlebot.com/)
 
 ## Formatting
 
-Learn.TurtleBot.com is powered by [Jekyll](http://jekyllrb.com/) and [hosted on GitHub pages](https://pages.github.com/).
+This site is powered by [Jekyll](http://jekyllrb.com/) and [hosted on GitHub pages](https://pages.github.com/).
 
 Friendly Tip for LAMP stack devs: You don't need to know anything about Ruby to use Jekyll.
+
+## Local testing
+
+If you would like to try viewing this locally.
+You can run the command `test_site_locally.bash`.
+
+This will run an instance of jekyll inside a docker container and expose it on
+<http://localhost:4000>.
+
+### Prerequisites
+
+To use the local testing script you will need to have installed Docker.
+[See the Docker Installation Instructions](https://docs.docker.com/engine/installation/)
+And make sure to add your user to the `docker` group.

--- a/_config.yml
+++ b/_config.yml
@@ -11,3 +11,6 @@ twitter_username: MWSilliman
 # Build settings
 markdown: kramdown
 permalink: pretty
+
+gems:
+  - jekyll-sitemap

--- a/test_site_locally.bash
+++ b/test_site_locally.bash
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -o errexit
+
+docker build -t "learn_turtlebot" .
+
+docker run -v `pwd`:/tmp/jekyll -w /tmp/jekyll -i -t --net=host learn_turtlebot


### PR DESCRIPTION
This adds a simple Dockerfile and script to enable local testing of the jekyll instance inside a docker container. 

And it adds a sitemap.xml for better search indexing. 
